### PR TITLE
integrate datetime_generator and get_ordered_col

### DIFF
--- a/synthetic_data/dataset_generator.py
+++ b/synthetic_data/dataset_generator.py
@@ -125,11 +125,12 @@ def generate_dataset(
                 )
             )
         else:
-            logging.warning(
-                f"""{name} is passed with sorting type of {sort}.
-            Ascending and descending are the only supported options.
-            No sorting action will be taken."""
-            )
+            if sort is not None:
+                logging.warning(
+                    f"""{name} is passed with sorting type of {sort}.
+                Ascending and descending are the only supported options.
+                No sorting action will be taken."""
+                )
             if col_generator == "datetime":
                 date = generated_data[:, 0]
                 dataset.append(date)

--- a/synthetic_data/dataset_generator.py
+++ b/synthetic_data/dataset_generator.py
@@ -105,10 +105,10 @@ def generate_dataset(
         else:
             name = col_generator
         col_generator_function = gen_funcs.get(col_generator)
+        sort = col_.pop("ordered", None)
         generated_data = col_generator_function(
             **col_, num_rows=dataset_length, rng=rng
         )
-        sort = col_.get("ordered", None)
 
         if sort in ["ascending", "descending"]:
             dataset.append(

--- a/synthetic_data/dataset_generator.py
+++ b/synthetic_data/dataset_generator.py
@@ -111,7 +111,7 @@ def generate_dataset(
         else:
             name = col_generator
         col_generator_function = gen_funcs.get(col_generator)
-        sort = col_.pop("ordered", None)
+        sort = col_.pop("order", None)
         generated_data = col_generator_function(
             **col_, num_rows=dataset_length, rng=rng
         )

--- a/synthetic_data/dataset_generator.py
+++ b/synthetic_data/dataset_generator.py
@@ -47,6 +47,10 @@ def get_ordered_column(
 
     :param data: numpy array to be sorted
     :type data: np.array
+    :param data_type: type of data to be sorted
+    :type data_type: str
+    :param order: order of sort. Options: ascending or descending
+    :type order: str
 
     :return: sorted numpy array
     """
@@ -95,6 +99,8 @@ def generate_dataset(
 
     dataset = []
     column_names = []
+    sorting_types = ["ascending", "descending"]
+
     for col in columns_to_generate:
         col_ = copy.deepcopy(col)
         col_generator = col_.pop("generator")
@@ -110,7 +116,14 @@ def generate_dataset(
             **col_, num_rows=dataset_length, rng=rng
         )
 
-        if sort in ["ascending", "descending"]:
+        if sort not in sorting_types:
+            logging.warning(
+                f"""{name} is passed with sorting type of {sort}.
+            Ascending and descending are the only supported options.
+            No sorting action will be taken."""
+            )
+
+        if sort in sorting_types:
             dataset.append(
                 get_ordered_column(
                     generated_data,

--- a/synthetic_data/dataset_generator.py
+++ b/synthetic_data/dataset_generator.py
@@ -116,13 +116,6 @@ def generate_dataset(
             **col_, num_rows=dataset_length, rng=rng
         )
 
-        if sort not in sorting_types:
-            logging.warning(
-                f"""{name} is passed with sorting type of {sort}.
-            Ascending and descending are the only supported options.
-            No sorting action will be taken."""
-            )
-
         if sort in sorting_types:
             dataset.append(
                 get_ordered_column(
@@ -132,6 +125,11 @@ def generate_dataset(
                 )
             )
         else:
+            logging.warning(
+                f"""{name} is passed with sorting type of {sort}.
+            Ascending and descending are the only supported options.
+            No sorting action will be taken."""
+            )
             if col_generator == "datetime":
                 date = generated_data[:, 0]
                 dataset.append(date)

--- a/synthetic_data/distinct_generators/datetime_generator.py
+++ b/synthetic_data/distinct_generators/datetime_generator.py
@@ -10,8 +10,8 @@ from numpy.random import Generator
 def generate_datetime(
     rng: Generator,
     date_format: str,
-    start_date: pd.Timestamp,
-    end_date: pd.Timestamp,
+    start_date: Optional[pd.Timestamp] = None,
+    end_date: Optional[pd.Timestamp] = None,
 ) -> str:
     """
     Generate datetime given the random_state, date_format, and start/end dates.
@@ -28,8 +28,8 @@ def generate_datetime(
         defaults to pd.Timestamp(2049, 12, 31)
     :type end_date: pd.Timestamp, None, optional
 
-    :return: generated datetime
-    :rtype: str
+    :return: list of generated datetime
+    :rtype: list[str, datetime]
     """
     if start_date is None:
         start_date: pd.Timestamp = pd.Timestamp(1920, 1, 1)

--- a/synthetic_data/distinct_generators/datetime_generator.py
+++ b/synthetic_data/distinct_generators/datetime_generator.py
@@ -1,4 +1,5 @@
 """Contains a datetime generator."""
+from datetime import datetime
 from typing import Optional
 
 import numpy as np
@@ -36,8 +37,8 @@ def generate_datetime(
         end_date: pd.Timestamp = pd.Timestamp(2049, 12, 31)
     t = rng.random()
     ptime = start_date + t * (end_date - start_date)
-
-    return ptime.strftime(date_format)
+    date_string = ptime.strftime(date_format)
+    return [date_string, datetime.strptime(date_string, date_format)]
 
 
 def random_datetimes(

--- a/tests/distinct_generators/test_datetime_generator.py
+++ b/tests/distinct_generators/test_datetime_generator.py
@@ -44,7 +44,7 @@ class TestDatetimeFunctions(unittest.TestCase):
                 format=self.generate_datetime_output[0],
             )
         except ValueError:
-            self.fail("pd.to_datetime() raised ValueError unexpectedly")
+            self.fail("pd.to_datetime() raised ValueError for custom formatting")
 
     def test_generate_datetime_range(self):
         date_obj = pd.to_datetime(

--- a/tests/distinct_generators/test_datetime_generator.py
+++ b/tests/distinct_generators/test_datetime_generator.py
@@ -8,7 +8,7 @@ from numpy.random import PCG64, Generator
 import synthetic_data.distinct_generators.datetime_generator as date_generator
 
 
-class TestDatetimeFunctions(unittest.TestCase):
+class TestGenerateDatetime(unittest.TestCase):
     def setUp(self):
         self.rng = Generator(PCG64(12345))
         self.start_date = pd.Timestamp(2001, 12, 22)
@@ -17,87 +17,91 @@ class TestDatetimeFunctions(unittest.TestCase):
         self.generate_datetime_output = date_generator.generate_datetime(
             self.rng, self.date_format_list[0], self.start_date, self.end_date
         )
+
+    def test_start_end_date_when_default(self):
+        date_str = self.generate_datetime_output
+        self.assertEqual("2006 10 02", date_str[0])
+        self.assertEqual(
+            datetime.strptime("2006 10 02", self.date_format_list[0]), date_str[1]
+        )
+
+    def test_generate_datetime(self):
+        self.assertEqual(
+            ["2006 10 02", datetime.strptime("2006 10 02", self.date_format_list[0])],
+            self.generate_datetime_output,
+        )
+        
+
+class TestRandomDatetimes(unittest.TestCase):
+    def setUp(self):
+        self.rng = Generator(PCG64(12345))
+        self.start_date = pd.Timestamp(2001, 12, 22)
+        self.end_date = pd.Timestamp(2023, 1, 1)
+        self.date_format_list = ["%Y %m %d"]
         self.random_datetimes_output = date_generator.random_datetimes(
             self.rng, self.date_format_list, self.start_date, self.end_date, 10
         )
 
-    def test_start_end_date_when_none(self):
-        date_str = date_generator.generate_datetime(
-            self.rng, self.date_format_list[0], start_date=None, end_date=None
-        )
-        try:
-            pd.to_datetime(date_str, format=self.date_format_list[0])
-        except:
-            self.fail(
-                "pd.to_datetime() raised ValueError for start_date, end_date = None"
+    def test_random_datetime_range(self):
+        for datetime in self.random_datetimes_output:
+            date_timestamp = pd.to_datetime(
+                datetime[0], format=self.date_format_list[0]
             )
-
-    def test_generate_datetime_return_type(self):
-        self.assertIsInstance(self.generate_datetime_output, list)
-        self.assertIsInstance(self.generate_datetime_output[0], str)
-        self.assertIsInstance(self.generate_datetime_output[1], datetime)
-        self.assertTrue(self.generate_datetime_output[0] == "2006 10 02")
-        self.assertTrue(
-            self.generate_datetime_output[1]
-            == datetime.strptime(
-                self.generate_datetime_output[0], self.date_format_list[0]
-            )
-        )
-
-    def test_generate_datetime_format(self):
-        try:
-            pd.to_datetime(
-                self.generate_datetime_output[1],
-                format=self.generate_datetime_output[0],
-            )
-        except ValueError:
-            self.fail("pd.to_datetime() raised ValueError for custom formatting")
-
-    def test_generate_datetime_range(self):
-        date_obj = pd.to_datetime(
-            self.generate_datetime_output[1], format=self.generate_datetime_output[0]
-        )
-        self.assertTrue(self.start_date <= date_obj)
-        self.assertTrue(date_obj <= self.end_date)
-
-    def test_random_datetimes_return_type_and_size(self):
-        self.assertIsInstance(self.random_datetimes_output, np.ndarray)
-        self.assertEqual(self.random_datetimes_output.shape[0], 10)
+            self.assertLessEqual(date_timestamp, self.end_date)
+            self.assertGreaterEqual(date_timestamp, self.start_date)
 
     def test_random_datetimes_default_format_usage(self):
-        dates = date_generator.random_datetimes(
-            self.rng, start_date=self.start_date, end_date=self.end_date
+        actual = date_generator.random_datetimes(
+            self.rng, start_date=self.start_date, end_date=self.end_date, num_rows=5
         )
-        for date in dates:
-            try:
-                pd.to_datetime(date, format="%B %d %Y %H:%M:%S")
-            except ValueError:
-                self.fail("pd.to_datetime() raised ValueError for default formatting")
+        expected = np.array(
+            [
+                ["March 12 2007 12:39:00", datetime(2007, 3, 12, 12, 39)],
+                ["December 04 2021 09:46:26", datetime(2021, 12, 4, 9, 46, 26)],
+                ["January 02 2016 09:12:26", datetime(2016, 1, 2, 9, 12, 26)],
+                ["December 28 2003 11:54:26", datetime(2003, 12, 28, 11, 54, 26)],
+                ["April 07 2011 07:53:14", datetime(2011, 4, 7, 7, 53, 14)],
+            ]
+        )
+        np.testing.assert_array_equal(expected, actual)
 
     def test_random_datetimes_format_usage(self):
+        expected = np.array(
+            [
+                ["December 04 2021 09:46:26", datetime(2021, 12, 4, 9, 46, 26)],
+                ["2016-01-02", datetime(2016, 1, 2, 0, 0)],
+                ["2011-04-07", datetime(2011, 4, 7, 0, 0)],
+                ["2020-08-12", datetime(2020, 8, 12, 0, 0)],
+                ["2008-11-02", datetime(2008, 11, 2, 0, 0)],
+            ]
+        )
         date_formats = ["%Y-%m-%d", "%B %d %Y %H:%M:%S"]
-        format_success = [False] * len(date_formats)
-        for date in self.random_datetimes_output:
-            for i in range(len(date_formats)):
-                try:
-                    pd.to_datetime(date[1], format=date[0])
-                    format_success[i] = True
-                except ValueError:
-                    pass
-        self.assertGreater(sum(format_success), 1)
+        actual = date_generator.random_datetimes(
+            self.rng,
+            date_formats,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            num_rows=5,
+        )
+        np.testing.assert_array_equal(expected, actual)
 
     def test_random_datetimes_output(self):
-        outputs = [
-            np.array(["2008 08 19", datetime(2008, 8, 19, 0, 0)]),
-            np.array(["2018 09 27", datetime(2018, 9, 27, 0, 0)]),
-            np.array(["2016 03 11", datetime(2016, 3, 11, 0, 0)]),
-            np.array(["2010 03 13", datetime(2010, 3, 13, 0, 0)]),
-            np.array(["2008 12 21", datetime(2008, 12, 21, 0, 0)]),
-            np.array(["2014 07 22", datetime(2014, 7, 22, 0, 0)]),
-            np.array(["2005 11 25", datetime(2005, 11, 25, 0, 0)]),
-            np.array(["2016 02 13", datetime(2016, 2, 13, 0, 0)]),
-            np.array(["2021 10 11", datetime(2021, 10, 11, 0, 0)]),
-            np.array(["2007 03 12", datetime(2007, 3, 12, 0, 0)]),
-        ]
+        expected = np.array(
+            [
+                ["2006 10 02", datetime(2006, 10, 2, 0, 0)],
+                ["2008 08 19", datetime(2008, 8, 19, 0, 0)],
+                ["2018 09 27", datetime(2018, 9, 27, 0, 0)],
+                ["2016 03 11", datetime(2016, 3, 11, 0, 0)],
+                ["2010 03 13", datetime(2010, 3, 13, 0, 0)],
+                ["2008 12 21", datetime(2008, 12, 21, 0, 0)],
+                ["2014 07 22", datetime(2014, 7, 22, 0, 0)],
+                ["2005 11 25", datetime(2005, 11, 25, 0, 0)],
+                ["2016 02 13", datetime(2016, 2, 13, 0, 0)],
+                ["2021 10 11", datetime(2021, 10, 11, 0, 0)],
+            ]
+        )
+
+        self.assertIsInstance(self.random_datetimes_output, np.ndarray)
+        self.assertEqual(self.random_datetimes_output.shape[0], 10)
         for i in range(len(self.random_datetimes_output)):
-            np.testing.assert_array_equal(self.random_datetimes_output[i], outputs[i])
+            np.testing.assert_array_equal(self.random_datetimes_output[i], expected[i])

--- a/tests/distinct_generators/test_datetime_generator.py
+++ b/tests/distinct_generators/test_datetime_generator.py
@@ -30,7 +30,7 @@ class TestGenerateDatetime(unittest.TestCase):
             ["2006 10 02", datetime.strptime("2006 10 02", self.date_format_list[0])],
             self.generate_datetime_output,
         )
-        
+
 
 class TestRandomDatetimes(unittest.TestCase):
     def setUp(self):

--- a/tests/distinct_generators/test_datetime_generator.py
+++ b/tests/distinct_generators/test_datetime_generator.py
@@ -36,6 +36,13 @@ class TestDatetimeFunctions(unittest.TestCase):
         self.assertIsInstance(self.generate_datetime_output, list)
         self.assertIsInstance(self.generate_datetime_output[0], str)
         self.assertIsInstance(self.generate_datetime_output[1], datetime)
+        self.assertTrue(self.generate_datetime_output[0] == "2006 10 02")
+        self.assertTrue(
+            self.generate_datetime_output[1]
+            == datetime.strptime(
+                self.generate_datetime_output[0], self.date_format_list[0]
+            )
+        )
 
     def test_generate_datetime_format(self):
         try:
@@ -94,12 +101,3 @@ class TestDatetimeFunctions(unittest.TestCase):
         ]
         for i in range(len(self.random_datetimes_output)):
             np.testing.assert_array_equal(self.random_datetimes_output[i], outputs[i])
-
-    def test_generate_datetime_output(self):
-        self.assertTrue(self.generate_datetime_output[0] == "2006 10 02")
-        self.assertTrue(
-            self.generate_datetime_output[1]
-            == datetime.strptime(
-                self.generate_datetime_output[0], self.date_format_list[0]
-            )
-        )

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -3,8 +3,6 @@ from collections import OrderedDict
 from datetime import datetime
 from unittest import mock
 
-pass
-
 import dataprofiler as dp
 import numpy as np
 import pandas as pd

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -121,8 +121,7 @@ class TestDatasetGenerator(unittest.TestCase):
             columns_to_generate=columns_to_gen,
             dataset_length=self.dataset_length,
         )
-
-        self.assertTrue(actual_df.equals(expected_df))
+        np.testing.assert_array_equal(actual_df, expected_df)
 
     def test_generate_dataset_with_invalid_generator(self):
         columns_to_gen = [{"generator": "non existent generator"}]
@@ -339,17 +338,36 @@ class TestGetOrderedColumn(unittest.TestCase):
 
         expected = np.array(
             [
-                "November 25 2005 02:50:42",
-                "August 19 2008 16:53:49",
-                "December 21 2008 00:15:47",
-                "March 13 2010 17:18:44",
-                "2018 09 27",
+                [
+                    "November 25 2005 02:50:42",
+                    datetime.strptime(
+                        "November 25 2005 02:50:42", custom_date_format[1]
+                    ),
+                ],
+                [
+                    "August 19 2008 16:53:49",
+                    datetime.strptime("August 19 2008 16:53:4", custom_date_format[1]),
+                ],
+                [
+                    "December 21 2008 00:15:47",
+                    datetime.strptime(
+                        "December 21 2008 00:15:47", custom_date_format[1]
+                    ),
+                ],
+                [
+                    "March 13 2010 17:18:44",
+                    datetime.strptime("March 13 2010 17:18:44", custom_date_format[1]),
+                ],
+                [
+                    "2018 09 27",
+                    datetime.strptime("2018 09 27", custom_date_format[0]),
+                ],
             ]
         )
 
         actual = dataset_generator.get_ordered_column(data, "datetime", "ascending")
 
-        np.testing.assert_array_equal(actual, expected)
+        np.testing.assert_array_equal(actual, expected[:, 0])
 
     def test_get_ordered_column_custom_datetime_descending(self):
         custom_date_format = ["%Y %m %d"]

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,7 +1,4 @@
 import unittest
-
-pass
-pass
 from unittest import mock
 
 import dataprofiler as dp
@@ -121,7 +118,7 @@ class TestDatasetGenerator(unittest.TestCase):
             columns_to_generate=columns_to_gen,
             dataset_length=self.dataset_length,
         )
-        np.testing.assert_array_equal(actual_df, expected_df)
+        np.testing.assert_array_equal(actual_df.values, expected_df.values)
 
     def test_generate_dataset_with_invalid_generator(self):
         columns_to_gen = [{"generator": "non existent generator"}]

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,5 +1,5 @@
 import unittest
-from collections import OrderedDict
+pass
 from datetime import datetime
 from unittest import mock
 
@@ -186,12 +186,12 @@ class TestDatasetGenerator(unittest.TestCase):
 
     @mock.patch("synthetic_data.dataset_generator.logging.warning")
     def test_generate_dataset_with_none_columns(self, mock_warning):
-        empty_dataframe = pd.DataFrame()
-        df = dataset_generator.generate_dataset(self.rng, None, self.dataset_length)
+        expected_dataframe = pd.DataFrame()
+        actual_df = dataset_generator.generate_dataset(self.rng, None, self.dataset_length)
         mock_warning.assert_called_once_with(
             "columns_to_generate is empty, empty dataframe will be returned."
         )
-        self.assertEqual(empty_dataframe.empty, df.empty)
+        self.assertEqual(expected_dataframe.empty, actual_df.empty)
 
     def test_generate_custom_dataset(self):
         expected_data = [

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -115,13 +115,13 @@ class TestDatasetGenerator(unittest.TestCase):
         expected_df = pd.DataFrame.from_dict(
             dict(zip(["int", "dat", "txt", "cat", "flo"], expected_data))
         )
-        df = dataset_generator.generate_dataset(
+        actual_df = dataset_generator.generate_dataset(
             self.rng,
             columns_to_generate=columns_to_gen,
             dataset_length=self.dataset_length,
         )
 
-        self.assertTrue(df.equals(expected_df))
+        self.assertTrue(actual_df.equals(expected_df))
 
     def test_generate_dataset_with_invalid_generator(self):
         columns_to_gen = [{"generator": "non existent generator"}]
@@ -221,12 +221,12 @@ class TestDatasetGenerator(unittest.TestCase):
         expected_df = pd.DataFrame.from_dict(
             dict(zip(["int", "dat", "txt", "cat", "flo"], expected_data))
         )
-        df = dataset_generator.generate_dataset(
+        actual_df = dataset_generator.generate_dataset(
             self.rng,
             columns_to_generate=self.columns_to_gen,
             dataset_length=self.dataset_length,
         )
-        self.assertTrue(df.equals(expected_df))
+        self.assertTrue(actual_df.equals(expected_df))
 
 
 class TestGetOrderedColumn(unittest.TestCase):
@@ -386,74 +386,3 @@ class TestGetOrderedColumn(unittest.TestCase):
         actual = dataset_generator.get_ordered_column(data, "datetime", "descending")
 
         np.testing.assert_array_equal(actual, expected[:, 0])
-
-    def test_get_ordered_column(self):
-
-        actual_data = OrderedDict(
-            {
-                "int": np.array([5, 4, 3, 2, 1]),
-                "float": np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
-                "string": np.array(["abcde", "bcdea", "cdeab", "deabc", "eabcd"]),
-                "categorical": np.array(["E", "D", "C", "B", "A"]),
-                "datetime": np.array(
-                    [
-                        [
-                            "September 27 2018 18:24:03",
-                            datetime.strptime(
-                                "September 27 2018 18:24:03", self.date_format_list[0]
-                            ),
-                        ],
-                        [
-                            "March 11 2016 15:15:39",
-                            datetime.strptime(
-                                "March 11 2016 15:15:39", self.date_format_list[0]
-                            ),
-                        ],
-                        [
-                            "March 13 2010 17:18:44",
-                            datetime.strptime(
-                                "March 13 2010 17:18:44", self.date_format_list[0]
-                            ),
-                        ],
-                        [
-                            "August 19 2008 16:53:49",
-                            datetime.strptime(
-                                "August 19 2008 16:53:49", self.date_format_list[0]
-                            ),
-                        ],
-                        [
-                            "October 02 2006 22:34:32",
-                            datetime.strptime(
-                                "October 02 2006 22:34:32", self.date_format_list[0]
-                            ),
-                        ],
-                    ]
-                ),
-            }
-        )
-
-        expected = [
-            np.array([1, 2, 3, 4, 5]),
-            np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
-            np.array(["abcde", "bcdea", "cdeab", "deabc", "eabcd"]),
-            np.array(["A", "B", "C", "D", "E"]),
-            np.array(
-                [
-                    "October 02 2006 22:34:32",
-                    "August 19 2008 16:53:49",
-                    "March 13 2010 17:18:44",
-                    "March 11 2016 15:15:39",
-                    "September 27 2018 18:24:03",
-                ]
-            ),
-        ]
-        expected = np.array(expected, dtype=object)
-
-        actual = []
-        for data_type in actual_data.keys():
-            actual.append(
-                dataset_generator.get_ordered_column(actual_data[data_type], data_type)
-            )
-        actual = np.array(actual)
-
-        np.testing.assert_array_equal(actual, expected)

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -341,7 +341,7 @@ class TestGetOrderedColumn(unittest.TestCase):
 
     def test_get_ordered_column(self):
 
-        data = OrderedDict(
+        actual_data = OrderedDict(
             {
                 "int": np.array([5, 4, 3, 2, 1]),
                 "float": np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
@@ -402,9 +402,9 @@ class TestGetOrderedColumn(unittest.TestCase):
         expected = np.array(expected, dtype=object)
 
         actual = []
-        for data_type in data.keys():
+        for data_type in actual_data.keys():
             actual.append(
-                dataset_generator.get_ordered_column(data[data_type], data_type)
+                dataset_generator.get_ordered_column(actual_data[data_type], data_type)
             )
         actual = np.array(actual)
 

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,4 +1,5 @@
 import unittest
+
 pass
 from datetime import datetime
 from unittest import mock
@@ -187,7 +188,9 @@ class TestDatasetGenerator(unittest.TestCase):
     @mock.patch("synthetic_data.dataset_generator.logging.warning")
     def test_generate_dataset_with_none_columns(self, mock_warning):
         expected_dataframe = pd.DataFrame()
-        actual_df = dataset_generator.generate_dataset(self.rng, None, self.dataset_length)
+        actual_df = dataset_generator.generate_dataset(
+            self.rng, None, self.dataset_length
+        )
         mock_warning.assert_called_once_with(
             "columns_to_generate is empty, empty dataframe will be returned."
         )

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,7 +1,7 @@
 import unittest
 
 pass
-from datetime import datetime
+pass
 from unittest import mock
 
 import dataprofiler as dp
@@ -245,42 +245,17 @@ class TestGetOrderedColumn(unittest.TestCase):
 
         expected = np.array(
             [
-                [
-                    "October 02 2006 22:34:32",
-                    datetime.strptime(
-                        "October 02 2006 22:34:32", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "August 19 2008 16:53:49",
-                    datetime.strptime(
-                        "August 19 2008 16:53:49", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "March 13 2010 17:18:44",
-                    datetime.strptime(
-                        "March 13 2010 17:18:44", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "March 11 2016 15:15:39",
-                    datetime.strptime(
-                        "March 11 2016 15:15:39", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "September 27 2018 18:24:03",
-                    datetime.strptime(
-                        "September 27 2018 18:24:03", self.date_format_list[0]
-                    ),
-                ],
+                "October 02 2006 22:34:32",
+                "August 19 2008 16:53:49",
+                "March 13 2010 17:18:44",
+                "March 11 2016 15:15:39",
+                "September 27 2018 18:24:03",
             ]
         )
 
         actual = dataset_generator.get_ordered_column(data, "datetime", "ascending")
 
-        np.testing.assert_array_equal(actual, expected[:, 0])
+        np.testing.assert_array_equal(actual, expected)
 
     def test_get_ordered_column_datetime_descending(self):
         data = datetime_generator.random_datetimes(
@@ -289,42 +264,17 @@ class TestGetOrderedColumn(unittest.TestCase):
 
         expected = np.array(
             [
-                [
-                    "September 27 2018 18:24:03",
-                    datetime.strptime(
-                        "September 27 2018 18:24:03", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "March 11 2016 15:15:39",
-                    datetime.strptime(
-                        "March 11 2016 15:15:39", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "March 13 2010 17:18:44",
-                    datetime.strptime(
-                        "March 13 2010 17:18:44", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "August 19 2008 16:53:49",
-                    datetime.strptime(
-                        "August 19 2008 16:53:49", self.date_format_list[0]
-                    ),
-                ],
-                [
-                    "October 02 2006 22:34:32",
-                    datetime.strptime(
-                        "October 02 2006 22:34:32", self.date_format_list[0]
-                    ),
-                ],
+                "September 27 2018 18:24:03",
+                "March 11 2016 15:15:39",
+                "March 13 2010 17:18:44",
+                "August 19 2008 16:53:49",
+                "October 02 2006 22:34:32",
             ]
         )
 
         actual = dataset_generator.get_ordered_column(data, "datetime", "descending")
 
-        np.testing.assert_array_equal(actual, expected[:, 0])
+        np.testing.assert_array_equal(actual, expected)
 
     def test_get_ordered_column_custom_datetime_ascending(self):
         custom_date_format = ["%Y %m %d", "%B %d %Y %H:%M:%S"]
@@ -338,36 +288,17 @@ class TestGetOrderedColumn(unittest.TestCase):
 
         expected = np.array(
             [
-                [
-                    "November 25 2005 02:50:42",
-                    datetime.strptime(
-                        "November 25 2005 02:50:42", custom_date_format[1]
-                    ),
-                ],
-                [
-                    "August 19 2008 16:53:49",
-                    datetime.strptime("August 19 2008 16:53:4", custom_date_format[1]),
-                ],
-                [
-                    "December 21 2008 00:15:47",
-                    datetime.strptime(
-                        "December 21 2008 00:15:47", custom_date_format[1]
-                    ),
-                ],
-                [
-                    "March 13 2010 17:18:44",
-                    datetime.strptime("March 13 2010 17:18:44", custom_date_format[1]),
-                ],
-                [
-                    "2018 09 27",
-                    datetime.strptime("2018 09 27", custom_date_format[0]),
-                ],
+                "November 25 2005 02:50:42",
+                "August 19 2008 16:53:49",
+                "December 21 2008 00:15:47",
+                "March 13 2010 17:18:44",
+                "2018 09 27",
             ]
         )
 
         actual = dataset_generator.get_ordered_column(data, "datetime", "ascending")
 
-        np.testing.assert_array_equal(actual, expected[:, 0])
+        np.testing.assert_array_equal(actual, expected)
 
     def test_get_ordered_column_custom_datetime_descending(self):
         custom_date_format = ["%Y %m %d"]
@@ -381,29 +312,14 @@ class TestGetOrderedColumn(unittest.TestCase):
 
         expected = np.array(
             [
-                [
-                    "2018 09 27",
-                    datetime.strptime("2018 09 27", custom_date_format[0]),
-                ],
-                [
-                    "2016 03 11",
-                    datetime.strptime("2016 03 11", custom_date_format[0]),
-                ],
-                [
-                    "2010 03 13",
-                    datetime.strptime("2010 03 13", custom_date_format[0]),
-                ],
-                [
-                    "2008 08 19",
-                    datetime.strptime("2008 08 19", custom_date_format[0]),
-                ],
-                [
-                    "2006 10 02",
-                    datetime.strptime("2006 10 02", custom_date_format[0]),
-                ],
+                "2018 09 27",
+                "2016 03 11",
+                "2010 03 13",
+                "2008 08 19",
+                "2006 10 02",
             ]
         )
 
         actual = dataset_generator.get_ordered_column(data, "datetime", "descending")
 
-        np.testing.assert_array_equal(actual, expected[:, 0])
+        np.testing.assert_array_equal(actual, expected)

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,11 +1,15 @@
 import unittest
+from collections import OrderedDict
+from datetime import datetime
 from unittest import mock
 
+import dataprofiler as dp
 import numpy as np
 import pandas as pd
 from numpy.random import PCG64, Generator
 
-from synthetic_data.dataset_generator import generate_dataset
+from synthetic_data import dataset_generator as dg
+from synthetic_data.distinct_generators import datetime_generator as dategen
 
 
 class TestDatasetGenerator(unittest.TestCase):
@@ -48,7 +52,7 @@ class TestDatasetGenerator(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "generator: non existent generator is not a valid generator."
         ):
-            generate_dataset(
+            dg.generate_dataset(
                 self.rng,
                 columns_to_generate=columns_to_gen,
                 dataset_length=self.dataset_length,
@@ -57,7 +61,7 @@ class TestDatasetGenerator(unittest.TestCase):
     @mock.patch("synthetic_data.dataset_generator.logging.warning")
     def test_generate_dataset_with_none_columns(self, mock_warning):
         empty_dataframe = pd.DataFrame()
-        df = generate_dataset(self.rng, None, self.dataset_length)
+        df = dg.generate_dataset(self.rng, None, self.dataset_length)
         mock_warning.assert_called_once_with(
             "columns_to_generate is empty, empty dataframe will be returned."
         )
@@ -91,8 +95,256 @@ class TestDatasetGenerator(unittest.TestCase):
         expected_df = pd.DataFrame.from_dict(
             dict(zip(["int", "dat", "txt", "cat", "flo"], expected_data))
         )
-        df = generate_dataset(
+        df = dg.generate_dataset(
             self.rng,
             columns_to_generate=self.columns_to_gen,
             dataset_length=self.dataset_length,
         )
+        self.assertTrue(df.equals(expected_df))
+
+
+class TestGetOrderedColumn(unittest.TestCase):
+    def setUp(self):
+        self.rng = Generator(PCG64(12345))
+        self.start_date = pd.Timestamp(2001, 12, 22)
+        self.end_date = pd.Timestamp(2023, 1, 1)
+        self.date_format_list = ["%B %d %Y %H:%M:%S"]
+
+    def test_get_ordered_column_datetime_ascending(self):
+        data = dategen.random_datetimes(
+            rng=self.rng, start_date=self.start_date, end_date=self.end_date, num_rows=5
+        )
+
+        ordered_data = np.array(
+            [
+                [
+                    "October 02 2006 22:34:32",
+                    datetime.strptime(
+                        "October 02 2006 22:34:32", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "August 19 2008 16:53:49",
+                    datetime.strptime(
+                        "August 19 2008 16:53:49", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "March 13 2010 17:18:44",
+                    datetime.strptime(
+                        "March 13 2010 17:18:44", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "March 11 2016 15:15:39",
+                    datetime.strptime(
+                        "March 11 2016 15:15:39", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "September 27 2018 18:24:03",
+                    datetime.strptime(
+                        "September 27 2018 18:24:03", self.date_format_list[0]
+                    ),
+                ],
+            ]
+        )
+
+        ordered_data = ordered_data[:, 0]
+        output_data = dg.get_ordered_column(data, "datetime", "ascending")
+
+        np.testing.assert_array_equal(output_data, ordered_data)
+
+    def test_get_ordered_column_datetime_descending(self):
+        data = dategen.random_datetimes(
+            rng=self.rng, start_date=self.start_date, end_date=self.end_date, num_rows=5
+        )
+
+        ordered_data = np.array(
+            [
+                [
+                    "September 27 2018 18:24:03",
+                    datetime.strptime(
+                        "September 27 2018 18:24:03", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "March 11 2016 15:15:39",
+                    datetime.strptime(
+                        "March 11 2016 15:15:39", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "March 13 2010 17:18:44",
+                    datetime.strptime(
+                        "March 13 2010 17:18:44", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "August 19 2008 16:53:49",
+                    datetime.strptime(
+                        "August 19 2008 16:53:49", self.date_format_list[0]
+                    ),
+                ],
+                [
+                    "October 02 2006 22:34:32",
+                    datetime.strptime(
+                        "October 02 2006 22:34:32", self.date_format_list[0]
+                    ),
+                ],
+            ]
+        )
+
+        ordered_data = ordered_data[:, 0]
+        output_data = dg.get_ordered_column(data, "datetime", "descending")
+
+        np.testing.assert_array_equal(output_data, ordered_data)
+
+    def test_get_ordered_column_custom_datetime_ascending(self):
+        custom_date_format = ["%Y %m %d"]
+        data = dategen.random_datetimes(
+            rng=self.rng,
+            date_format_list=custom_date_format,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            num_rows=5,
+        )
+
+        ordered_data = np.array(
+            [
+                [
+                    "2006 10 02",
+                    datetime.strptime("2006 10 02", custom_date_format[0]),
+                ],
+                [
+                    "2008 08 19",
+                    datetime.strptime("2008 08 19", custom_date_format[0]),
+                ],
+                [
+                    "2010 03 13",
+                    datetime.strptime("2010 03 13", custom_date_format[0]),
+                ],
+                [
+                    "2016 03 11",
+                    datetime.strptime("2016 03 11", custom_date_format[0]),
+                ],
+                [
+                    "2018 09 27",
+                    datetime.strptime("2018 09 27", custom_date_format[0]),
+                ],
+            ]
+        )
+
+        ordered_data = ordered_data[:, 0]
+        output_data = dg.get_ordered_column(data, "datetime", "ascending")
+
+        np.testing.assert_array_equal(output_data, ordered_data)
+
+    def test_get_ordered_column_custom_datetime_descending(self):
+        custom_date_format = ["%Y %m %d"]
+        data = dategen.random_datetimes(
+            rng=self.rng,
+            date_format_list=custom_date_format,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            num_rows=5,
+        )
+
+        ordered_data = np.array(
+            [
+                [
+                    "2018 09 27",
+                    datetime.strptime("2018 09 27", custom_date_format[0]),
+                ],
+                [
+                    "2016 03 11",
+                    datetime.strptime("2016 03 11", custom_date_format[0]),
+                ],
+                [
+                    "2010 03 13",
+                    datetime.strptime("2010 03 13", custom_date_format[0]),
+                ],
+                [
+                    "2008 08 19",
+                    datetime.strptime("2008 08 19", custom_date_format[0]),
+                ],
+                [
+                    "2006 10 02",
+                    datetime.strptime("2006 10 02", custom_date_format[0]),
+                ],
+            ]
+        )
+
+        ordered_data = ordered_data[:, 0]
+        output_data = dg.get_ordered_column(data, "datetime", "descending")
+
+        np.testing.assert_array_equal(output_data, ordered_data)
+
+    def test_get_ordered_column(self):
+
+        data = OrderedDict(
+            {
+                "int": np.array([5, 4, 3, 2, 1]),
+                "float": np.array([5.0, 4.0, 3.0, 2.0, 1.0]),
+                "string": np.array(["abcde", "bcdea", "cdeab", "deabc", "eabcd"]),
+                "categorical": np.array(["E", "D", "C", "B", "A"]),
+                "datetime": np.array(
+                    [
+                        [
+                            "September 27 2018 18:24:03",
+                            datetime.strptime(
+                                "September 27 2018 18:24:03", self.date_format_list[0]
+                            ),
+                        ],
+                        [
+                            "March 11 2016 15:15:39",
+                            datetime.strptime(
+                                "March 11 2016 15:15:39", self.date_format_list[0]
+                            ),
+                        ],
+                        [
+                            "March 13 2010 17:18:44",
+                            datetime.strptime(
+                                "March 13 2010 17:18:44", self.date_format_list[0]
+                            ),
+                        ],
+                        [
+                            "August 19 2008 16:53:49",
+                            datetime.strptime(
+                                "August 19 2008 16:53:49", self.date_format_list[0]
+                            ),
+                        ],
+                        [
+                            "October 02 2006 22:34:32",
+                            datetime.strptime(
+                                "October 02 2006 22:34:32", self.date_format_list[0]
+                            ),
+                        ],
+                    ]
+                ),
+            }
+        )
+
+        ordered_data = [
+            np.array([1, 2, 3, 4, 5]),
+            np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+            np.array(["abcde", "bcdea", "cdeab", "deabc", "eabcd"]),
+            np.array(["A", "B", "C", "D", "E"]),
+            np.array(
+                [
+                    "October 02 2006 22:34:32",
+                    "August 19 2008 16:53:49",
+                    "March 13 2010 17:18:44",
+                    "March 11 2016 15:15:39",
+                    "September 27 2018 18:24:03",
+                ]
+            ),
+        ]
+        ordered_data = np.array(ordered_data, dtype=object)
+
+        output_data = []
+        for data_type in data.keys():
+            output_data.append(dg.get_ordered_column(data[data_type], data_type))
+        output_data = np.array(output_data)
+
+        np.testing.assert_array_equal(output_data, ordered_data)


### PR DESCRIPTION
Replacement to PR https://github.com/capitalone/synthetic-data/pull/318
Integrated get_ordered_columns into dataset_generator.
Reimplemented datetime_generator to work with get_ordered_column.
Implemented unit and integration tests.