### PR TITLE
Fix Requirements to match dataprofiler - scipy>=1.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.22
+numpy>=1.22.0
 scikit-learn>=1.1.0
-scipy==1.8.0
-dataprofiler>=0.8.8
+scipy>=1.10.0
+dataprofiler>=0.10.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def parse_requirements(filename):
     return [line for line in lineiter if line and not line.startswith("#")]
 
 
-with open("README.md") as readme:
+with open('README.md', mode='r', encoding='utf8') as readme:
     long_description = readme.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def parse_requirements(filename):
     return [line for line in lineiter if line and not line.startswith("#")]
 
 
-with open('README.md', mode='r', encoding='utf8') as readme:
+with open("README.md", encoding="utf8") as readme:
     long_description = readme.read()
 
 setup(


### PR DESCRIPTION
Closes
https://github.com/capitalone/synthetic-data/issues/280
https://github.com/capitalone/synthetic-data/issues/340

Synced requirements between dataprofiler and synthetic-data
Rationale for choosing dataprofiler>=0.10.3 was based on trying to sync on scipy>=1.10.0
https://github.com/capitalone/DataProfiler/blob/0.10.3/requirements.txt#L13
dataprofiler 0.10.3 - increased compatibility to scipy>=1.10.0 ; 

Please review and let me know if you require any changes. 
Thanks & regards. 
